### PR TITLE
Remove unnecessary requirements from Python hello world app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,1 @@
-click==6.7
 Flask==1.0.2
-itsdangerous==0.24
-Jinja2==2.10
-MarkupSafe==1.0
-Werkzeug==0.14.1


### PR DESCRIPTION
The Python Flask hello world app works fine with only Flask==1.0.2 as a requirement. The Azure App Service for Linux automatically installs Flask's dependent requirements for you. Specifying all the dependent requirements in requirements.txt makes a hello world app seem more difficult than it really is. Suggest removing unnecessary lines.